### PR TITLE
jd: add version v1.5.1

### DIFF
--- a/bucket/jd.json
+++ b/bucket/jd.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.5.1",
+    "description": "jd is a commandline utility and Go library for diffing and patching JSON values.",
+    "homepage": "https://github.com/josephburnett/jd",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/josephburnett/jd/releases/download/v1.5.1/jd-amd64-windows#/jd.exe",
+            "hash": "15b4c753868b4e727347eab457d66aed671681f39f5d3872d51f15d7d959efea"
+        }
+    },
+    "bin": "jd.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/josephburnett/jd/releases/download/v$version/jd-amd64-windows#/jd.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[jd](https://github.com/josephburnett/jd) is a commandline utility and Go library for diffing and patching JSON values.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
